### PR TITLE
Redmine 5 compatibility (wrong file import)

### DIFF
--- a/app/models/repository/git_lab.rb
+++ b/app/models/repository/git_lab.rb
@@ -2,7 +2,7 @@ require 'redmine/scm/adapters/git_adapter'
 require 'pathname'
 require 'fileutils'
 # require 'open3'
-require_dependency 'redmine_git_remote/poor_mans_capture3'
+require File.dirname(__FILE__) + '/../../../lib/redmine_git_remote/poor_mans_capture3'
 
 class Repository::GitLab < Repository::Git
 

--- a/app/models/repository/git_remote.rb
+++ b/app/models/repository/git_remote.rb
@@ -2,7 +2,7 @@ require 'redmine/scm/adapters/git_adapter'
 require 'pathname'
 require 'fileutils'
 # require 'open3'
-require_dependency 'redmine_git_remote/poor_mans_capture3'
+require File.dirname(__FILE__) + '/../../../lib/redmine_git_remote/poor_mans_capture3'
 
 class Repository::GitRemote < Repository::Git
 

--- a/init.rb
+++ b/init.rb
@@ -1,5 +1,5 @@
 require 'redmine'
-require_dependency "redmine_git_remote/repositories_helper_patch"
+File.dirname(__FILE__) +  "/lib/redmine_git_remote/repositories_helper_patch"
 
 Redmine::Scm::Base.add "GitRemote"
 Redmine::Scm::Base.add "GitLab"


### PR DESCRIPTION
No idea why, but looks like both file requires where wrong in previous releases, but just now Redmine (5) validates not found dependencies
Also, no idea if poor_mans_capture3 is still required 